### PR TITLE
Add support for optional arguments to git status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,11 @@ branding:
 inputs:
   status-args:
     description: "Arguments to the `git status` command."
+    required: false
     default: ""
   pathspec:
     description: "Pattern used to limit paths in the `git status` command."
+    required: false
     default: ""
 outputs:
   changed:

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,19 @@ description: "Check if a git repository has uncommitted changes"
 branding:
   icon: "info"
   color: "yellow"
+inputs:
+  status-args:
+    description: "Arguments to the `git status` command."
+    default: ""
+  pathspec:
+    description: "Pattern used to limit paths in the `git status` command."
+    default: ""
 outputs:
   changed:
-    description: "Whether or not there are uncommitted changes in the folder"
+    description: "Whether or not there are uncommitted changes in the pathspec"
 runs:
   using: "docker"
   image: "Dockerfile"
+  args: 
+    - ${{ inputs.status-args }}
+    - ${{ inputs.pathspec }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -e
 
+echo "git status --porcelain $1 $2"
+
 function check() {
-  if [[ -z "$(git status --porcelain)" ]];
+  if [[ -z "$(git status --porcelain $1 $2)" ]];
   then
     echo "0"
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
-echo "git status --porcelain $1 $2"
+STATUS_ARGS=$1
+PATHSPEC=$2
 
 function check() {
-  if [[ -z "$(git status --porcelain $1 $2)" ]];
+  if [[ -z "$(git status --porcelain $STATUS_ARGS $PATHSPEC)" ]];
   then
     echo "0"
   else


### PR DESCRIPTION
I thought this would solve a problem I was working on, but realized later that it won't.  It still might be valuable, especially if you want to look for changes only in a specific directory/file (new `pathspec` input).