### PR TITLE
Introduce changes output variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You do this by checking if `changed` is equal to `1`.
 
 The value will be 0 if no code has been changed by any previous steps.
 
+You can print list of all changes by printing `changes` variable in the step. 
+
 ## Example
 
 ```yaml
@@ -38,6 +40,8 @@ jobs:
     - name: Process changes
       if: steps.changes.outputs.changed == 1
       run: echo "Changes exist"
+    # You can print list of changes if needed
+    # run: echo "Changes exist: " && echo "${{ steps.changes.outputs.changes }}"
 ```
 
 The example shows that adding a step to check the status will expose the

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,8 @@ inputs:
 outputs:
   changed:
     description: "Whether or not there are uncommitted changes in the pathspec"
+  changes:
+    description: "Describes list of uncommitted changes in the pathspec"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,29 @@
 #!/bin/bash
-set -e
 
 STATUS_ARGS=$1
 PATHSPEC=$2
 
 function check() {
-  if [[ -z "$(git status --porcelain $STATUS_ARGS $PATHSPEC)" ]];
+  set -e
+  output=$(git status --porcelain $STATUS_ARGS $PATHSPEC)
+  set +e
+
+  echo "$output"
+  if [[ -z "$output" ]];
   then
-    echo "0"
+    return 0
   else
-    echo "1"
+    return 1
   fi
 }
 
-echo ::set-output name=changed::$(check)
+changes=$(check)
+changed=$?
+
+# Escape result
+changes="${changes//'%'/'%25'}"
+changes="${changes//$'\n'/'%0A'}"
+changes="${changes//$'\r'/'%0D'}"
+
+echo ::set-output name=changed::$changed
+echo ::set-output name=changes::$changes


### PR DESCRIPTION
This adds new output variable `changes` containing git status result, so the next step in pipeline can print this and give user better idea what is wrong.

Cross link [CAMEL-15552](https://issues.apache.org/jira/browse/CAMEL-15552)